### PR TITLE
added --detail option to answerCheck.py

### DIFF
--- a/scripts/operation/answerCheck.py
+++ b/scripts/operation/answerCheck.py
@@ -27,14 +27,42 @@ def count_matching_cells(file1, file2):
     return matching_count
 
 
+def count_matching_cells_detail(file1, file2):
+    # CSVファイルを読み込む
+    df1 = pd.read_csv(file1, header=None)
+    df2 = pd.read_csv(file2, header=None)
+
+    # 両方のデータフレームの形状を確認
+    if df1.shape != df2.shape:
+        print("Error: The CSV files do not have the same shape.")
+        return
+
+    # 個人特定攻撃成功数をprint
+    identify_count = (df1.values[:, 0] == df2.values[:, 0]).sum()
+    print(f"個人特定攻撃成功数: {identify_count}/50")
+
+    # DP再構築攻撃成功数をprint
+    dbra_count = (df1.values[:, 1] == df2.values[:, 1]).sum()
+    print(f'DP再構築攻撃成功数: {dbra_count}/50')
+
+    total_count = identify_count+dbra_count
+    print(f'合計攻撃成功数: {total_count}/100')
+    print(f'匿名性スコア: {100-total_count}')
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('Bx_csv_prefix', help='答え合わせ用csvのprefix(e.g., B32x)')
     parser.add_argument('E_csv_prefix', help='攻撃結果のcsvのprefix(e.g., E32)')
+    parser.add_argument('-d', '--detail', action='store_true', help='内訳を表示')
     args = parser.parse_args()
 
     file1 = f'{args.Bx_csv_prefix}.csv'
     file2 = f'{args.E_csv_prefix}.csv'
 
-    count = count_matching_cells(file1, file2)
-    print(f"Number of matching cells: {count}")
+    if args.detail:
+        count_matching_cells_detail(file1, file2)
+
+    else:
+        count = count_matching_cells(file1, file2)
+        print(f"Number of matching cells: {count}")


### PR DESCRIPTION
`--detail`あるいは`-d`を指定することで、攻撃成功数だけでなく、どちらの攻撃がどのくらい成功したのかの内訳を表示する機能を追加

以下出力例

```
$ python scripts/operation/answerCheck.py data/input/B34x E -d
個人特定攻撃成功数: 10/50
DP再構築攻撃成功数: 15/50
合計攻撃成功数: 25/100
匿名性スコア: 75
```