### PR TITLE
有用性評価方法の更新：issue59対応

### DIFF
--- a/scripts/evaluate/utilityScoreSingle.py
+++ b/scripts/evaluate/utilityScoreSingle.py
@@ -42,6 +42,12 @@ def find_max_mae_and_columns(file1, file2, parallel=1):
       column_pair = [c1, c2]
       freq1 = df1.value_counts(column_pair)
       freq2 = df2.value_counts(column_pair)
+
+      # インデックスをユニオンで統一
+      index_union = freq1.index.union(freq2.index)
+      # reindexを使ってインデックスを統一し、存在しない要素は0にする
+      freq1 = freq1.reindex(index_union, fill_value=0)
+      freq2 = freq2.reindex(index_union, fill_value=0)
       err_dic[",".join(column_pair)] = (freq1 - freq2).abs().sum()
 
     # MAEの規格化


### PR DESCRIPTION
#59  に対応しています。

[課題]
MAEの計算に際して、加工前後で集計項目が一致していないことがあります
　例えば、すべての男性を女性に置き換えると、加工後のクロス集計には男性での集計列が無くなる
　加工前後の週系列で差を取ると、NaNとの差はNaNになるが、本来は0との比較をするべき。
　
[対応]
utilityScoreSingle.pyにて、集計項目を揃えるように、indexを加工前後で一致させるようにして、NaNの箇所は0にしました。

```python
      # インデックスをユニオンで統一
      index_union = freq1.index.union(freq2.index)
      # reindexを使ってインデックスを統一し、存在しない要素は0にする
      freq1 = freq1.reindex(index_union, fill_value=0)
      freq2 = freq2.reindex(index_union, fill_value=0)
```

以下、テスト結果です。ID94の有用性が悪化しています。この処理によって有用性が改善することはないので、結果は妥当です。
ID94のデータの詳細は調査済みです。現状の実装により、正しく計算できています。C94は加工により、クロス集計表の比較の際に1件NAが発生しており、従前はこれを誤差なしと解釈していました。
有用性指標の実装を更新して、こちらの誤差を参入することで、1/20000=0.005悪化しています。「正解の値」を更新して、99.895 -> 99.890にする必要があります。

| ID  | UtilityScore最小値 | 正解の値 | 一致 |
|-----|---------------------|----------|------|
| 80  | 100.000             | 100.0    | ○    |
| 81  | 99.970              | 99.970   | ○    |
| 82  | 99.920              | 99.920   | ○    |
| 83  | 99.910              | 99.910   | ○    |
| 84  | 99.900              | 99.900   | ○    |
| 90  | 100.000             | 100.0    | ○    |
| 91  | 99.970              | 99.970   | ○    |
| 92  | 99.900              | 99.900   | ○    |
| 93  | 99.900              | 99.900   | ○    |
| 94  | 99.890              | 99.895   | ✕    | < -ここ
